### PR TITLE
remove leading backslash from docker.name

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,19 @@ Then output becomes as belows
   }
 }
 ```
-
+## Running Tests
+```
+bundle install
+bundle exec rake test
+```
 ## Contributing
 
 1. Fork it
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
+5. Update and verify tests are successful (See `Running Tests`)
+6. Create new Pull Request
 
 ## Copyright
   Copyright (c) 2015 jimmidyson

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Then output becomes as belows
   "stream": "stderr",
   "docker": {
     "id": "df14e0d5ae4c07284fa636d739c8fc2e6b52bc344658de7d3f08c36a2e804115",
-    "name": "/k8s_fabric8-console-container.efbd6e64_fabric8-console-controller-9knhj_default_8ae2f621-f360-11e4-8d12-54ee7527188d_7ec9aa3e",
+    "name": "k8s_fabric8-console-container.efbd6e64_fabric8-console-controller-9knhj_default_8ae2f621-f360-11e4-8d12-54ee7527188d_7ec9aa3e",
     "container_hostname": "fabric8-console-controller-9knhj",
     "image": "fabric8/hawtio-kubernetes:latest",
     "image_id": "b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303",

--- a/lib/fluent/plugin/filter_docker_metadata.rb
+++ b/lib/fluent/plugin/filter_docker_metadata.rb
@@ -62,7 +62,7 @@ module Fluent
           es.each {|time, record|
             record['docker'] = {
               'id' => metadata['id'],
-              'name' => metadata['Name'],
+              'name' => metadata['Name'][1..-1],
               'container_hostname' => metadata['Config']['Hostname'],
               'image' => metadata['Config']['Image'],
               'image_id' => metadata['Image'],

--- a/test/plugin/test_filter_docker_metadata.rb
+++ b/test/plugin/test_filter_docker_metadata.rb
@@ -78,7 +78,7 @@ class DockerMetadataFilterTest < Test::Unit::TestCase
         es = emit('', messages)
         assert_equal(4, es.instance_variable_get(:@record_array).size)
         assert_equal('df14e0d5ae4c07284fa636d739c8fc2e6b52bc344658de7d3f08c36a2e804115', es.instance_variable_get(:@record_array)[0]['docker']['id'])
-        assert_equal('/k8s_fabric8-console-container.efbd6e64_fabric8-console-controller-9knhj_default_8ae2f621-f360-11e4-8d12-54ee7527188d_7ec9aa3e', es.instance_variable_get(:@record_array)[0]['docker']['name'])
+        assert_equal('k8s_fabric8-console-container.efbd6e64_fabric8-console-controller-9knhj_default_8ae2f621-f360-11e4-8d12-54ee7527188d_7ec9aa3e', es.instance_variable_get(:@record_array)[0]['docker']['name'])
         assert_equal('fabric8-console-controller-9knhj', es.instance_variable_get(:@record_array)[0]['docker']['container_hostname'])
         assert_equal('b2bd1a24a68356b2f30128e6e28e672c1ef92df0d9ec01ec0c7faea5d77d2303', es.instance_variable_get(:@record_array)[0]['docker']['image_id'])
         assert_equal('fabric8/hawtio-kubernetes:latest', es.instance_variable_get(:@record_array)[0]['docker']['image'])


### PR DESCRIPTION
Issue #7 

cuts off first character of docker.name, which is always a / in the case of our infrastructure. Leaving just the name.
