### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent-plugin-docker_metadata_filter.gemspec
+++ b/fluent-plugin-docker_metadata_filter.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.has_rdoc      = false
 
-  gem.required_ruby_version = '>= 1.9.3'
+  gem.required_ruby_version = '>= 2.1.0'
 
-  gem.add_runtime_dependency "fluentd"
+  gem.add_runtime_dependency "fluentd", [">= 0.14.0", "< 2"]
   gem.add_runtime_dependency "docker-api"
   gem.add_runtime_dependency "lru_redux"
 

--- a/lib/fluent/plugin/filter_docker_metadata.rb
+++ b/lib/fluent/plugin/filter_docker_metadata.rb
@@ -16,8 +16,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-module Fluent
-  class DockerMetadataFilter < Fluent::Filter
+require 'fluent/plugin/filter'
+
+module Fluent::Plugin
+  class DockerMetadataFilter < Fluent::Plugin::Filter
     Fluent::Plugin.register_filter('docker_metadata', self)
 
     config_param :docker_url, :string,  :default => 'unix:///var/run/docker.sock'
@@ -57,7 +59,7 @@ module Fluent
         metadata = @cache.getset(container_id){DockerMetadataFilter.get_metadata(container_id)}
 
         if metadata
-          new_es = MultiEventStream.new
+          new_es = Fluent::MultiEventStream.new
 
           es.each {|time, record|
             record['docker'] = {
@@ -72,7 +74,6 @@ module Fluent
           }
         end
       end
-
       return new_es
     end
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -31,6 +31,8 @@ require 'test/unit/rr'
 require 'fileutils'
 require 'fluent/log'
 require 'fluent/test'
+require 'fluent/test/driver/filter'
+require 'fluent/test/helpers'
 require 'webmock/test_unit'
 require 'vcr'
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -64,5 +64,3 @@ def ipv6_enabled?
     false
   end
 end
-
-$log = Fluent::Log.new(Fluent::Test::DummyLogDevice.new, Fluent::Log::LEVEL_WARN)


### PR DESCRIPTION
If fluentd plugins use and inherits its class v0.14 API, Fluentd permits to send nanosecond precision time and append time zone information.
If this patches are acceptable for this plugin developers, please review carefully and follow this upgrading from v0.12 (old style) guideline: http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12

Regards,